### PR TITLE
feat(chore): removed exoego on his own request, changed hamy username, added vscode snippet

### DIFF
--- a/modules/fomantic/github/repositories.tf
+++ b/modules/fomantic/github/repositories.tf
@@ -1,11 +1,11 @@
 locals {
   repos = {
     Fomantic-UI           = {
-      description   = "Fomantic-UI is a community fork of Semantic-UI"
+      description   = "Fomantic-UI is the official community fork of Semantic-UI"
       homepage_url  = "https://fomantic-ui.com"
       topics        = [
-        "ui", "css-framework", "semantic", "fork",
-        "fomantic", "fomantic-ui", "component-library"
+        "javascript", "css", "ui", "css-framework", "semantic", "fork",
+        "fomantic", "fomantic-ui", "component-library", "hacktoberfest"
       ]
       has_downloads = true
       has_issues    = true
@@ -69,7 +69,7 @@ locals {
       has_wiki      = true
     }
     create-fomantic-icons = {
-      description   = "Generate the icon.overrides and icon.html.eco files for Fomantic-UI (or Semantic-UI)"
+      description   = "Generate the icon.variables and icon.html.eco files for Fomantic-UI (or Semantic-UI)"
       homepage_url  = ""
       topics        = [
         "fomantic-ui", "semantic-ui", "fontawesome", "icons", "fomantic"
@@ -111,6 +111,17 @@ locals {
       has_issues    = true
       has_projects  = false
       has_wiki      = false
+    }
+    Fomantic-UI-vscode-snippets = {
+      description   = "Fomantic-UI Snippets for VS Code"
+      homepage_url  = ""
+      topics        = [
+        "fomantic-ui", "fomantic", "vscode", "snippets"
+      ]
+      has_downloads = true
+      has_issues    = true
+      has_projects  = true
+      has_wiki      = true
     }
   }
 }

--- a/vars.github.tf
+++ b/vars.github.tf
@@ -83,7 +83,7 @@ variable "github_members" {
   description   = "GitHub organisation members"
   type          = map(string)
   default       = {
-    hammy2899   = "admin" // organisation owner
+    y0hami      = "admin" // organisation owner
     prudho      = "member"
     ColinFrick  = "member"
     lubber-de   = "admin"
@@ -99,7 +99,7 @@ variable "github_member_teams" {
   type        = map(map(string))
   default     = {
     admins        = {
-      hammy2899   = "maintainer"
+      y0hami      = "maintainer"
       prudho      = "member"
       ColinFrick  = "member"
       lubber-de   = "member"
@@ -108,11 +108,11 @@ variable "github_member_teams" {
       fomanticbot = "member"
     }
     helpers       = {
-      hammy2899   = "maintainer"
+      y0hami      = "maintainer"
     }
     maintainers   = {
-      hammy2899   = "maintainer"
-      ko2in      = "member"
+      y0hami      = "maintainer"
+      ko2in       = "member"
     }
   }
 }

--- a/vars.github.tf
+++ b/vars.github.tf
@@ -61,6 +61,7 @@ variable "github_team_repository_access" {
       branding              = "admin"
       infrastructure        = "push"
       rfcs                  = "admin"
+      Fomantic-UI-vscode-snippets = "admin"
     }
     bots        = {
       Fomantic-UI       = "push"
@@ -86,7 +87,6 @@ variable "github_members" {
     prudho      = "member"
     ColinFrick  = "member"
     lubber-de   = "admin"
-    exoego      = "member"
     ko2in       = "member"
 
     // bots
@@ -112,7 +112,6 @@ variable "github_member_teams" {
     }
     maintainers   = {
       hammy2899   = "maintainer"
-      exoego      = "member"
       ko2in      = "member"
     }
   }


### PR DESCRIPTION
## Description
I am not sure how much we still use this repo for auto adjustment of fomantic repos, as i think it gets much faster these days doing things directly inside the related github repo itself and **i am a bit afraid about the stored IP Adresses to stay up-to-date**.

Nevertheless, this PR sadly removes exoego as a org member on [his own request](https://github.com/orgs/fomantic/teams/maintainers/discussions/1)
This also changes to hamy new username [y0hami](https://github.com/y0hami)

The PR also adds the vscode snippet extension repo. We already have many more repos and also forked some, but i dont feel all of them have to be maintained via this extra repo.

However, this PR is made to keep par on the most important settings which are already done in the original repos. By merging it the github flow would do changes in the original repo...i am bit afraid to do it without really knowing what happens 😨 
